### PR TITLE
Prune extra forward slash

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,6 +233,11 @@ function readVarint(buf, offset) {
       }
     }, false);
   })
+
+  function joinPath(a, b) {
+    return (a[a.length - 1] === "/" ? a : a + "/") + b
+  }
+
   function onSearch() {
     let sb = document.getElementById('sb').value;
     if (sb == "") {
@@ -242,7 +247,7 @@ function readVarint(buf, offset) {
     if (window.location != window.parent.location) {
       p = document.referrer
     }
-    fetch(p + '/cid/' + sb)
+    fetch(`${joinPath(p,'cid')}/${sb}`)
       .then((response) => {
         if (response.status >= 200 && response.status <= 299) {
           return response.json();


### PR DESCRIPTION
Queries are failing from the infra.cid.contact website since this adds an extra `/` to the query which results in a 301 which doesn't have the CORS header. This removes that extra `/` so should hit the correct endpoint and get the proper CORS header back.
